### PR TITLE
ci: add golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: go
+
+on:
+  push:
+    tags:
+    - v*
+    branches:
+    - master
+    - main
+  pull_request:
+    branches:
+    - main
+    paths:
+    - '**.go'
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,67 @@
+run:
+  timeout: 5m
+  issues-exit-code: 1
+  tests: true
+
+linters-settings:
+  cyclop:
+    max-complexity: 10
+    package-average: 0.0
+  dupl:
+    threshold: 100
+  errorlint:
+    errorf: true
+    asserts: true
+    comparison: true
+  gocognit:
+    min-complexity: 10
+  nestif:
+    min-complexity: 4
+  goconst:
+    min-len: 3
+    min-occurrences: 3
+  gocritic:
+    enabled-tags:
+    - performance
+    - diagnostic
+    - style
+    - opinionated
+    disabled-tags:
+    - experimental
+  godot:
+    scope: all
+  gofmt:
+    simplify: true
+  goimports:
+    local-prefixes: github.com/gocatchup/gocatchup
+  golint:
+    min-confidence: 0.0
+  gosimple:
+    go: "1.16"
+  govet:
+    check-shadowing: true
+    enable-all: true
+  nakedret:
+    max-func-lines: 1
+  staticcheck:
+    go: "1.16"
+  unused:
+    go: "1.16"
+
+linters:
+  presets:
+  - bugs
+  - unused
+  - style
+  - error
+  - performance
+  - complexity
+  - comment
+  - import
+  - format
+  disable:
+  - misspell
+
+issues:
+  exclude-use-default: false
+  max-same-issues: 50

--- a/build/test.sh
+++ b/build/test.sh
@@ -28,27 +28,3 @@ TARGETS=$(for d in "$@"; do echo ./$d/...; done)
 echo "Running tests:"
 go test -installsuffix "static" ${TARGETS}
 echo
-
-echo -n "Checking gofmt: "
-ERRS=$(find "$@" -type f -name \*.go | xargs gofmt -l 2>&1 || true)
-if [ -n "${ERRS}" ]; then
-    echo "FAIL - the following files need to be gofmt'ed:"
-    for e in ${ERRS}; do
-        echo "    $e"
-    done
-    echo
-    exit 1
-fi
-echo "PASS"
-echo
-
-echo -n "Checking go vet: "
-ERRS=$(go vet ${TARGETS} 2>&1 || true)
-if [ -n "${ERRS}" ]; then
-    echo "FAIL"
-    echo "${ERRS}"
-    echo
-    exit 1
-fi
-echo "PASS"
-echo

--- a/cmd/gocatchup/main.go
+++ b/cmd/gocatchup/main.go
@@ -1,3 +1,4 @@
+// Package main the the entry point for the gocatcup command.
 package main
 
 import (
@@ -6,5 +7,6 @@ import (
 
 func main() {
 	println(version.Version)
+
 	println("Go catchup!")
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,6 @@
+// Package version version specifies the version of the applications.
 package version
 
 // Version define the version of the application.
+//nolint: gochecknoglobals
 var Version = "UNKOWN"


### PR DESCRIPTION
Add https://golangci-lint.run/ and enable most linters. This might be a
bit overkill but we can eaisly remove linters when we see them doing
more harm then good.

Configuration: https://golangci-lint.run/usage/configuration/
Linters: https://golangci-lint.run/usage/linters/