### PR TITLE
docs: update README and make commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A newsletter to keep up with Go.
 
-## Development
+## Documentation
 
-You can check our [developemnt docuemntation](./docs/development/README.md) for
-more information.
+- [Development](./docs/development/README.md)
+- [RFCs](./docs/rfc)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -7,6 +7,12 @@ as of Go 1.13) and vendoring (which reasonable minds might disagree about).  You
 will need to run `go mod vendor` to create a `vendor` directory when you have
 dependencies.
 
+## Makefile
+
+The `Makefile` is the single source of truth of how to run things. Every task
+that you need to run on this project can be found inside of the Makefile. To see
+all the commands you can run use `make help`.
+
 ## Building
 
 Run `make` or `make build` to compile your app.  This will use a Docker image to
@@ -30,3 +36,8 @@ Run `make help` to get a list of available targets.
 
 Run `make test` will run your tests inside of a docker container. If you want to
 run tests locally you can run `./build/test.sh` directly.
+
+## Starting shell inside of container
+
+It might be useful to start a shell inside of the build container. To start an
+interactive shell run `make shell`.


### PR DESCRIPTION
## docs: update readme to show all documentation dirs

Make it more clear that we use RFCs and have documentation for
development.

## docs: document makefile commands

- Document `make help` command
- Document `make shell` command