### PR TITLE
build: add make lint command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,17 @@ container-clean:
 bin-clean:
 	rm -rf .go bin
 
+lint: # @HELP run all available linters
+lint: golint
+
+golint:
+	@docker run                        \
+	    --rm                           \
+	    -v $$(pwd):/app                \
+	    -w /app                        \
+	    golangci/golangci-lint:v1.41.1 \
+	    golangci-lint run
+
 help: # @HELP prints this message
 help:
 	@echo "VARIABLES:"


### PR DESCRIPTION
Create a new make target `make lint` to run all the linters, for now
just running the `golangci-lint` docker container.