### PR TITLE
ci: use pat to delete ghcr image tag

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -22,5 +22,5 @@ jobs:
       with:
         owner: ${{ github.repository_owner }}
         name: ${{ github.event.repository.name }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PAT }}
         tag: pr-${{ github.event.pull_request.number }}__linux_amd64


### PR DESCRIPTION
Fix errors like
https://github.com/gocatchup/gocatchup/runs/3050188065?check_suite_focus=true
where `GITHUB_TOKEN` doesn't have the correct permissions. The
documentation in https://github.com/bots-house/ghcr-delete-image-action
specifies to use PAT.